### PR TITLE
Prevent NullPointerException for call parleyErrorResponse::getNotification

### DIFF
--- a/parley/src/main/java/nu/parley/android/Parley.java
+++ b/parley/src/main/java/nu/parley/android/Parley.java
@@ -73,7 +73,7 @@ public final class Parley {
     private boolean loadingMore = false;
     private boolean refreshingMessages = false;
 
-    private boolean doRequestPushPermission = true;
+    private boolean requestNotificationPermission = true;
 
     private Parley() {
         // Hide default constructor
@@ -244,12 +244,12 @@ public final class Parley {
         getInstance().messagesManager.disableCaching();
     }
 
-    public static void disableRequestPushPermission() {
-        getInstance().doRequestPushPermission = false;
+    public static void setRequestNotificationPermission(Boolean permission) {
+        getInstance().requestNotificationPermission = permission;
     }
 
-    public static Boolean doRequestPushPermission() {
-        return getInstance().doRequestPushPermission;
+    public static Boolean getRequestNotificationPermission() {
+        return getInstance().requestNotificationPermission;
     }
 
     /**

--- a/parley/src/main/java/nu/parley/android/data/net/response/ParleyErrorResponse.java
+++ b/parley/src/main/java/nu/parley/android/data/net/response/ParleyErrorResponse.java
@@ -19,7 +19,7 @@ public final class ParleyErrorResponse {
 
     @Nullable
     private ParleyNotificationResponse getNotification() {
-        if (notifications.isEmpty()) {
+        if (notifications == null || notifications.isEmpty()) {
             return null;
         }
         return notifications.get(0);

--- a/parley/src/main/java/nu/parley/android/view/ParleyView.java
+++ b/parley/src/main/java/nu/parley/android/view/ParleyView.java
@@ -295,7 +295,7 @@ public final class ParleyView extends FrameLayout implements ParleyListener, Con
             Parley.getInstance().setListener(this);
             connectivityMonitor.register(getContext(), this);
             accessibilityMonitor.register(getContext(), this);
-            if (Parley.doRequestPushPermission()) {
+            if (Parley.getRequestNotificationPermission()) {
                 requestPermissionsIfNeeded();
             }
         } else {


### PR DESCRIPTION
Our proxy apparently doesn't return the right (read expected) json error structure, this results in a crash. This change will prevent that crash. We'll need to deal with handling the errors but first we'll need to prevent the crash.
It would be cool if you could merge this into master and bump to >3.9.3

Kind Regards,
Diederick 
Kotlin/Android developer
Triodos