### PR TITLE
Prevent NullPointerException for call parleyErrorResponse::getNotification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.9.2 - 14 May 2024
+
+- Added `Parley.setRequestNotificationPermission(enabled)` to control whether Parley should request notification permissions and handle the channels. 
+  - By default this is `true`, where Parley will handle the permission request and create the notification channels when needed. 
+  - **NOTE**: When disabling this, it's required to handle requesting the notification permission in another way, as well as creating the notification channels that are required for Parley to work properly.
+
 ## 3.9.1 - 16 Apr 2024
 
 - Added `setInterceptor(interceptor)` to ParleyNetwork to be able to apply a custom interceptor.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation "com.google.firebase:firebase-messaging:23.4.1"
 
     // Library
-//    implementation 'com.github.parley-messaging:android-library:3.9.1' // Remote
+//    implementation 'com.github.parley-messaging:android-library:3.9.2' // Remote
     implementation project(':parley') // Local
 
     // Tests

--- a/parley/build.gradle
+++ b/parley/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 
 group = 'com.github.parley-messaging'
-version = '3.9.1'
+version = '3.9.2'
 
 android {
     namespace 'nu.parley.android'

--- a/parley/src/main/java/nu/parley/android/Parley.java
+++ b/parley/src/main/java/nu/parley/android/Parley.java
@@ -236,7 +236,7 @@ public final class Parley {
     /**
      * Disable offline messaging.
      * <p>
-     * <b>Note:</b>* The `clear()` method will be called on the current instance to prevent unused data on the device.
+     * <b>Note:</b> The `clear()` method will be called on the current instance to prevent unused data on the device.
      * </p>
      */
     @SuppressWarnings("unused")
@@ -244,8 +244,16 @@ public final class Parley {
         getInstance().messagesManager.disableCaching();
     }
 
-    public static void setRequestNotificationPermission(Boolean permission) {
-        getInstance().requestNotificationPermission = permission;
+    /**
+     * Set whether Parley should request notification permission and create the channels needed for Parley to work properly.
+     * By default this is `true`, where Parley will handle the permission request and create the notification channels when needed.
+     * <p>
+     * <b>Note:</b> When disabling this, it's required to handle requesting the notification permission in another way, as well as creating the notification channels that are required for Parley to work properly.
+     * </p>
+     */
+    @SuppressWarnings("unused")
+    public static void setRequestNotificationPermission(Boolean enabled) {
+        getInstance().requestNotificationPermission = enabled;
     }
 
     public static Boolean getRequestNotificationPermission() {

--- a/parley/src/main/java/nu/parley/android/Parley.java
+++ b/parley/src/main/java/nu/parley/android/Parley.java
@@ -73,7 +73,7 @@ public final class Parley {
     private boolean loadingMore = false;
     private boolean refreshingMessages = false;
 
-    private boolean doRequestPushPermission = true;
+    private boolean requestNotificationPermission = true;
 
     private Parley() {
         // Hide default constructor
@@ -244,12 +244,12 @@ public final class Parley {
         getInstance().messagesManager.disableCaching();
     }
 
-    public static void disableRequestPushPermission() {
-        getInstance().doRequestPushPermission = false;
+    public static void setRequestNotificationPermission(Boolean permission) {
+        getInstance().requestNotificationPermission = permission;
     }
 
-    public static Boolean doRequestPushPermission() {
-        return getInstance().doRequestPushPermission;
+    public static Boolean getRequestNotificationPermission() {
+        return getInstance().requestNotificationPermission;
     }
 
     /**

--- a/parley/src/main/java/nu/parley/android/view/ParleyView.java
+++ b/parley/src/main/java/nu/parley/android/view/ParleyView.java
@@ -295,7 +295,7 @@ public final class ParleyView extends FrameLayout implements ParleyListener, Con
             Parley.getInstance().setListener(this);
             connectivityMonitor.register(getContext(), this);
             accessibilityMonitor.register(getContext(), this);
-            if (Parley.doRequestPushPermission()) {
+            if (Parley.getRequestNotificationPermission()) {
                 requestPermissionsIfNeeded();
             }
         } else {


### PR DESCRIPTION
Our proxy apparently doesn't return the right (read expected) json error structure, this results in a crash. This change will prevent that crash. We'll need to deal with handling the errors but first we'll need to prevent the crash.
It would be cool if you could merge this into master and bump to >3.9.3

Kind Regards,
Diederick
Kotlin/Android developer
Triodos